### PR TITLE
Add support for C in CMake and update build instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.9.0)
-project(opengl_intro LANGUAGES CXX)
+project(opengl_intro)
 set(CMAKE_CXX_STANDARD 17)
 
 # Add GLFW

--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ mkdir build
 cd build
 cmake ..
 ```
+
+If you are on Windows and using Visual Studio, the solution and project files will be generated. Otherwise, you 
+can run 
+`make` in the `build` directory. 


### PR DESCRIPTION
C language support is required to build successfully. Removing the `LANGUAGES` keyword defaults to `C` and `CXX`.